### PR TITLE
fix(generic-utils): add missing Lombok dependency in pom.xml

### DIFF
--- a/generic-utils/pom.xml
+++ b/generic-utils/pom.xml
@@ -34,6 +34,12 @@
             <artifactId>commons-lang3</artifactId>
             <version>3.17.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.38</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
 </project>


### PR DESCRIPTION
Summary
This PR addresses a build issue in the generic-utils module by adding the missing Lombok dependency to its pom.xml.

Changes Made
Added Lombok dependency to generic-utils/pom.xml

Ensures support for annotations such as @Getter, @Setter, @Builder, etc.