### PR TITLE
fix(date-util): update module version from 1.0 to 1.0.1 in pom.xml

### DIFF
--- a/date-util/pom.xml
+++ b/date-util/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.selenium-framework</groupId>
         <artifactId>selenium-framework</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>date-util</artifactId>


### PR DESCRIPTION
Summary
This PR updates the date-util module version from 1.0 to 1.0.1 in its pom.xml to reflect minor changes and maintain semantic versioning alignment across the project.

Changes Made
Updated version tag in date-util/pom.xml from 1.0 to 1.0.1