### PR TITLE
fix(date-util): add Lombok dependency in pom.xml

### DIFF
--- a/date-util/pom.xml
+++ b/date-util/pom.xml
@@ -18,4 +18,13 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.38</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
 </project>


### PR DESCRIPTION
Summary
Added Lombok dependency to the date-util module to enable the use of annotations like @Getter, @Setter, and @Builder.

Changes Made
Updated date-util/pom.xml to include Lombok dependency