### PR TITLE
feat(generic-utils): add LoadProperties utility for config management

### DIFF
--- a/generic-utils/pom.xml
+++ b/generic-utils/pom.xml
@@ -35,6 +35,11 @@
             <version>3.17.0</version>
         </dependency>
         <dependency>
+            <groupId>org.selenium-framework</groupId>
+            <artifactId>logging-util</artifactId>
+            <version>1.0.1-SNAPSHOT</version>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>1.18.38</version>

--- a/generic-utils/src/main/java/com/central/framework/genericutils/LoadProperties.java
+++ b/generic-utils/src/main/java/com/central/framework/genericutils/LoadProperties.java
@@ -1,0 +1,31 @@
+package org.seleniumframework.utils;
+
+import lombok.extern.slf4j.Slf4j;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.Properties;
+
+@Slf4j
+public final class LoadProperties {
+
+    // Private constructor to prevent instantiation
+    private LoadProperties() {}
+
+    /**
+     * Loads and returns properties from a given file path.
+     *
+     * @param filePath Absolute or relative path to the .properties file
+     * @return Properties object loaded with key-value pairs
+     * @throws RuntimeException if the file cannot be read
+     */
+    public static Properties fromFile(String filePath) {
+        Properties properties = new Properties();
+        try (FileInputStream fis = new FileInputStream(filePath)) {
+            properties.load(fis);
+        } catch (IOException e) {
+            log.error("Error loading property file from filepath {}",filePath, e);
+            throw new RuntimeException("Failed to load properties file: " + filePath, e);
+        }
+        return properties;
+    }
+}


### PR DESCRIPTION
Summary
This PR introduces a LoadProperties utility in the generic-utils module for handling configuration files, and adds the logging-util module to the central project structure.

Changes Made

generic-utils:
Added LoadProperties utility to load .properties files for configuration

logging-util:
Integrated the module into the parent POM for centralized logging support