### PR TITLE
Fix/packagging from pom to jar

### DIFF
--- a/date-util/pom.xml
+++ b/date-util/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>date-util</artifactId>
-    <packaging>pom</packaging>
+    <packaging>jar</packaging>
 
     <properties>
         <maven.compiler.source>17</maven.compiler.source>

--- a/excel-utils/pom.xml
+++ b/excel-utils/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>excel-utils</artifactId>
-    <packaging>pom</packaging>
+    <packaging>jar</packaging>
 
     <properties>
         <maven.compiler.source>17</maven.compiler.source>

--- a/generic-utils/pom.xml
+++ b/generic-utils/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>generic-utils</artifactId>
-    <packaging>pom</packaging>
+    <packaging>jar</packaging>
 
     <properties>
         <maven.compiler.source>17</maven.compiler.source>

--- a/generic-utils/src/main/java/com/central/framework/genericutils/LoadProperties.java
+++ b/generic-utils/src/main/java/com/central/framework/genericutils/LoadProperties.java
@@ -1,4 +1,4 @@
-package org.seleniumframework.utils;
+package com.central.framework.genericutils;
 
 import lombok.extern.slf4j.Slf4j;
 import java.io.FileInputStream;

--- a/logging-util/pom.xml
+++ b/logging-util/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>logging-util</artifactId>
-    <packaging>pom</packaging>
+    <packaging>jar</packaging>
 
     <properties>
         <maven.compiler.source>17</maven.compiler.source>

--- a/report-util/pom.xml
+++ b/report-util/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>report-util</artifactId>
-    <packaging>pom</packaging>
+    <packaging>jar</packaging>
 
     <properties>
         <maven.compiler.source>17</maven.compiler.source>

--- a/selenium-driver-util/pom.xml
+++ b/selenium-driver-util/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>selenium-driver-util</artifactId>
-    <packaging>pom</packaging>
+    <packaging>jar</packaging>
 
     <properties>
         <maven.compiler.source>17</maven.compiler.source>


### PR DESCRIPTION
Summary
Updated all utility modules to use jar packaging instead of pom, allowing them to be compiled and reused as standard Maven artifacts.

Modules Updated

selenium-driver-util
date-util
report-util
generic-utils
excel-util
logging-util

Impact

Ensures each module generates a .jar file
Enables better integration across modules and projects consuming them
Resolves issues with dependency resolution in multi-module setup