### PR TITLE
refactor(driver-init): replace loadProperties method with LoadPropert…

### DIFF
--- a/selenium-driver-util/pom.xml
+++ b/selenium-driver-util/pom.xml
@@ -31,6 +31,11 @@
         </dependency>
         <dependency>
             <groupId>org.selenium-framework</groupId>
+            <artifactId>generic-utils</artifactId>
+            <version>1.0.1-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.selenium-framework</groupId>
             <artifactId>logging-util</artifactId>
             <version>1.0.1-SNAPSHOT</version>
         </dependency>

--- a/selenium-driver-util/src/main/java/com/central/framework/selenium/DriverInitializer.java
+++ b/selenium-driver-util/src/main/java/com/central/framework/selenium/DriverInitializer.java
@@ -1,15 +1,11 @@
 package com.central.framework.selenium;
 
+import com.central.framework.genericutils.LoadProperties;
 import com.central.framework.selenium.enums.Browsers;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.openqa.selenium.WebDriver;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.util.Objects;
 import java.util.Properties;
 
 @Slf4j
@@ -18,17 +14,10 @@ public class DriverInitializer {
     private static final ThreadLocal<WebDriver> driverThreadLocal = new ThreadLocal<>();
     @Getter
     private static Properties properties;
-    private static final String propertyFileName = "driver-config.properties";
 
-    public static void initializeWebDriver(String browserName) {
+    public static void initializeWebDriver(String browserName,String filePath) {
         DriverManager driverManager = new DriverManager();
-        try {
-            loadDriverProperty();
-        } catch (URISyntaxException | IOException e) {
-            log.error("Error loading driver property file", e);
-            throw new RuntimeException("Failed to load properties file", e);
-        }
-
+        properties=LoadProperties.fromFile(filePath);
         driverManager.setProperties(properties);
         WebDriver driver = driverManager.getWebDriver(Browsers.valueOf(browserName));
         driverThreadLocal.set(driver);
@@ -47,24 +36,6 @@ public class DriverInitializer {
         if (driver != null) {
             driver.quit();
             driverThreadLocal.remove();
-        }
-    }
-
-    private static void loadDriverProperty() throws URISyntaxException, IOException {
-        if (properties == null) {
-            String propertiesPath = System.getProperty("driver.config.path");
-            properties = new Properties();
-            File propertyFile;
-
-            if (propertiesPath != null && !propertiesPath.isEmpty()) {
-                propertyFile = new File(propertiesPath);
-            } else {
-                propertyFile = new File(Objects.requireNonNull(
-                        Thread.currentThread().getContextClassLoader().getResource(propertyFileName)
-                ).toURI());
-            }
-
-            properties.load(new FileInputStream(propertyFile));
         }
     }
 


### PR DESCRIPTION
Summary
This PR removes the local loadProperties method from DriverInitializer and replaces it with the LoadProperties utility class from the generic-utils module.

Changes Made
Removed duplicated loadProperties method from DriverInitializer
Integrated LoadProperties utility for reading configuration files
Promotes cleaner code and better utility reuse

Impact
Improves maintainability by centralizing property loading logic
Eliminates redundant code across the framework