### PR TITLE
feat: add AssertUtil for detailed assertion logging and define standa…

### DIFF
--- a/assert-util/pom.xml
+++ b/assert-util/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.selenium-framework</groupId>
+        <artifactId>selenium-framework</artifactId>
+        <version>1.0.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>assert-util</artifactId>
+    <packaging>jar</packaging>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <central.framework.version>1.0.1-SNAPSHOT</central.framework.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>7.11.0</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.selenium-framework</groupId>
+            <artifactId>logging-util</artifactId>
+            <version>${central.framework.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.selenium-framework</groupId>
+            <artifactId>report-util</artifactId>
+            <version>${central.framework.version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/assert-util/src/main/java/com/central/framework/assertutil/CustomAssert.java
+++ b/assert-util/src/main/java/com/central/framework/assertutil/CustomAssert.java
@@ -1,0 +1,71 @@
+package com.central.framework.assertutil;
+
+import com.central.framework.reportutils.ExtentReportManager;
+import com.aventstack.extentreports.Status;
+import org.testng.asserts.SoftAssert;
+import org.testng.Assert;
+
+public class CustomAssert {
+
+    private static final ThreadLocal<SoftAssert> softAssertThreadLocal = ThreadLocal.withInitial(SoftAssert::new);
+
+    // ===== HARD ASSERT METHODS ===== //
+
+    public static void assertEqualsHard(Object actual, Object expected, String message) {
+        try {
+            Assert.assertEquals(actual, expected);
+            ExtentReportManager.getTest().log(Status.PASS,
+                    message + " | ✅ Expected: " + expected + " | Actual: " + actual);
+        } catch (AssertionError e) {
+            ExtentReportManager.getTest().log(Status.FAIL,
+                    message + " | ❌ Expected: " + expected + " | Actual: " + actual + " | Exception: " + e.getMessage());
+            throw e; // rethrow to fail the test immediately
+        }
+    }
+
+    public static void assertTrueHard(boolean condition, String message) {
+        try {
+            Assert.assertTrue(condition);
+            ExtentReportManager.getTest().log(Status.PASS, message + " | ✅ Condition is true");
+        } catch (AssertionError e) {
+            ExtentReportManager.getTest().log(Status.FAIL, message + " | ❌ Condition is false | Exception: " + e.getMessage());
+            throw e;
+        }
+    }
+
+    // ===== SOFT ASSERT METHODS ===== //
+
+    public static void assertEqualsSoft(Object actual, Object expected, String message) {
+        try {
+            softAssertThreadLocal.get().assertEquals(actual, expected);
+            ExtentReportManager.getTest().log(Status.INFO,
+                    message + " | 🧪 (Soft) Expected: " + expected + " | Actual: " + actual);
+        } catch (AssertionError e) {
+            ExtentReportManager.getTest().log(Status.WARNING,
+                    message + " | ❌ (Soft) Assertion failed | Expected: " + expected + " | Actual: " + actual + " | Exception: " + e.getMessage());
+        }
+    }
+
+    public static void assertTrueSoft(boolean condition, String message) {
+        try {
+            softAssertThreadLocal.get().assertTrue(condition);
+            ExtentReportManager.getTest().log(Status.INFO, message + " | 🧪 (Soft) Condition is true");
+        } catch (AssertionError e) {
+            ExtentReportManager.getTest().log(Status.WARNING, message + " | ❌ (Soft) Condition failed | Exception: " + e.getMessage());
+        }
+    }
+
+    // ===== SOFT ASSERT FINALIZER ===== //
+
+    public static void assertAllSoft(String summaryMessage) {
+        try {
+            softAssertThreadLocal.get().assertAll();
+            ExtentReportManager.getTest().log(Status.PASS, summaryMessage + " | ✅ All soft assertions passed.");
+        } catch (AssertionError e) {
+            ExtentReportManager.getTest().log(Status.FAIL, summaryMessage + " | ❌ One or more soft assertions failed: " + e.getMessage());
+            throw e;
+        } finally {
+            softAssertThreadLocal.remove(); // Clean up to avoid memory leaks in parallel tests
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
         <module>generic-utils</module>
         <module>logging-util</module>
         <module>excel-utils</module>
+        <module>assert-util</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
Summary
This PR adds a new AssertUtil class for enriched assertion logging and introduces a standalone pom.xml file to allow independent execution of the framework.

Features Added

AssertUtil
Logs actual vs expected values during assertions
Supports both soft and hard assertion types
Integrates with ExtentReports for improved visibility

Standalone pom.xml
Enables the framework to be run or packaged independently
Supports modular structure while maintaining clean separation of concerns